### PR TITLE
36 auto delete dislike videos / DisLike動画の自動削除機能（通知なし）を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,4 @@ gem 'qiita'
 gem 'pry-rails'
 
 gem 'kaminari'
+

--- a/app/controllers/youtube/myvideos/status/dislike_controller.rb
+++ b/app/controllers/youtube/myvideos/status/dislike_controller.rb
@@ -1,4 +1,6 @@
 class Youtube::Myvideos::Status::DislikeController < ApplicationController
+  before_action :expired_dislike_myvideos_destroy_setting, only: [:index]
+
   def index
     @dislike_myvideos = []
     keyword = params[:keyword]
@@ -27,6 +29,19 @@ class Youtube::Myvideos::Status::DislikeController < ApplicationController
       dislike_myvideo.destroy
       dislike_myvideo.favorites.destroy
       redirect_to youtube_myvideos_status_dislike_index_path
+    end
+  end
+
+  private
+
+  def expired_dislike_myvideos_destroy_setting
+    time = Time.now
+    dislike_youtube_videos = YoutubeVideo.where(status: 'dislike')
+    dislike_youtube_videos.each do |dislike_youtube_video|
+      if dislike_youtube_video.is_remaining &&  dislike_youtube_video.updated_at < time.ago(7.days)
+        dislike_youtube_video.update(is_remaining: 'false')
+        dislike_youtube_video.save!
+      end
     end
   end
 end

--- a/app/controllers/youtube/myvideos/status/dislike_controller.rb
+++ b/app/controllers/youtube/myvideos/status/dislike_controller.rb
@@ -1,5 +1,6 @@
 class Youtube::Myvideos::Status::DislikeController < ApplicationController
   before_action :expired_dislike_myvideos_destroy_setting, only: [:index]
+  before_action :expired_dislike_myvideos_destroy!, only: [:index]
 
   def index
     @dislike_myvideos = []
@@ -31,9 +32,10 @@ class Youtube::Myvideos::Status::DislikeController < ApplicationController
       redirect_to youtube_myvideos_status_dislike_index_path
     end
   end
-
+  
+  
   private
-
+  
   def expired_dislike_myvideos_destroy_setting
     time = Time.now
     dislike_youtube_videos = YoutubeVideo.where(status: 'dislike')
@@ -44,4 +46,10 @@ class Youtube::Myvideos::Status::DislikeController < ApplicationController
       end
     end
   end
+  
+  def expired_dislike_myvideos_destroy!
+    expired_dislike_youtube_videos = YoutubeVideo.where(status: 'dislike', is_remaining: 'false')
+    expired_dislike_youtube_videos.destroy_all
+  end
+  
 end

--- a/app/controllers/youtube/myvideos/status/like_controller.rb
+++ b/app/controllers/youtube/myvideos/status/like_controller.rb
@@ -1,5 +1,4 @@
 class Youtube::Myvideos::Status::LikeController < ApplicationController
-  require 'kaminari'
 
   def index
     @like_myvideos = []

--- a/app/models/youtube_video.rb
+++ b/app/models/youtube_video.rb
@@ -1,8 +1,10 @@
 class YoutubeVideo < ApplicationRecord
+  
   has_many :favorites, dependent: :destroy
   has_many :users, through: :favorites
   has_many :users, through: :share_videos
 
   enum status: { default: 0, like: 1, dislike: 2 }
+  enum is_remaining: { true: 0, false: 1 }
   validates :video_id, uniqueness: { scope: :user_id }
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,14 +26,14 @@
 
         <i class="fas fa-sign-out-alt fa-2x"></i>
   <% end %>
-      <span>ログアウト</span>
+      <p style="text-align: center;">ログアウト</p>
 
       </div>
       <div class="user-action-common">
         <%= link_to edit_user_registration_path do %>
           <i class="fas fa-pencil-alt fa-2x"></i>
         <% end %>
-        <span>情報を編集<span>
+        <p style="text-align: center;">情報を編集</p>
       </div>
     </div>
   <% end %>

--- a/app/views/youtube/myvideos/status/dislike/index.html.erb
+++ b/app/views/youtube/myvideos/status/dislike/index.html.erb
@@ -149,7 +149,7 @@
             font-size:8px;
             "
            >
-            <%= dislike_myvideo.created_at.since(7.days).strftime('%Y/%m/%d') %>に自動削除されます
+            <%= dislike_myvideo.updated_at.since(7.days).strftime('%Y/%m/%d') %>に自動削除されます
           </div>
         </div>
       

--- a/db/migrate/20210123071806_create_youtube_videos.rb
+++ b/db/migrate/20210123071806_create_youtube_videos.rb
@@ -10,6 +10,7 @@ class CreateYoutubeVideos < ActiveRecord::Migration[6.0]
       t.string :channel_title
       t.string :thumbnail_url
       t.integer :status, null: false, default: 0
+      t.integer :is_remaining, null: false, default: 0
       t.string :search_keyword
       t.references :user, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2021_02_21_143603) do
     t.string "channel_title"
     t.string "thumbnail_url"
     t.integer "status", default: 0, null: false
+    t.integer "is_remaining", default: 0, null: false
     t.string "search_keyword"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/seeds/user.rb
+++ b/db/seeds/user.rb
@@ -1,0 +1,26 @@
+p "create Users for demo operating"
+
+User.create!(
+  email: 'hoge@mail.com',
+  password: 'demopass',
+  name: 'hoge',
+  self_introduction: 'hogeです',
+  gender: 0,
+  profile_image: open("#{Rails.root}/db/dummy_images/6.jpg")
+)
+User.create!(
+  email: 'fuga@mail.com',
+  password: 'demopass',
+  name: 'fuga',
+  self_introduction: 'hogeです',
+  gender: 0,
+  profile_image: open("#{Rails.root}/db/dummy_images/6.jpg")
+)
+User.create!(
+  email: 'gege@mail.com',
+  password: 'demopass',
+  name: 'gege',
+  self_introduction: 'hogeです',
+  gender: 0,
+  profile_image: open("#{Rails.root}/db/dummy_images/6.jpg")
+)

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,0 +1,6 @@
+Dir.glob(File.join(Rails.root, 'db', 'seeds', '*.rb')).each do |file|
+  desc "Load the seed data from db/seeds/#{File.basename(file)}."
+  task "db:seed:#{File.basename(file).gsub(/\..+$/, '')}" => :environment do
+    load(file)
+  end
+end


### PR DESCRIPTION
### 7日期限でDisLike動画が自動削除されるように実装する
#### 自動削除フラグの実装
```is_remaining```カラムをYoutubeVideosテーブルに追加
自動削除フラグとして使用
```is_remaining```のtrue/falseの条件 → #120 
close #120

#### 自動削除処理をメソッド実装
```before_action```コールバックとの組み合わせにより
DisLike動画一覧ページ表示ページ表示前に
```is_remaining```がtrueのレコードを削除するメソッドを実装
→ ```Youtube::Myvideos::Status::DislikeController#expired_dislike_myvideos_destroy!```メソッド

close #123 

#### 通知なしのためcronは不使用
close #122 

#### seedファイル別管理
afe08f3
close #121