### PR TITLE
45 like users page / タイプユーザー一覧ページを実装

### DIFF
--- a/app/controllers/users/status/like_controller.rb
+++ b/app/controllers/users/status/like_controller.rb
@@ -1,0 +1,31 @@
+class Users::Status::LikeController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+
+    like_reactions = Reaction.where(from_user_id: @user.id, status: "like").order(created_at: "DESC")
+
+    like_reaction_dates = []
+    like_reactions.each do |like_reaction|
+      like_reaction_dates << like_reaction.created_at
+    end
+
+    @like_reaction_dates = like_reaction_dates
+
+    like_user_ids = Reaction.where(from_user_id: @user.id, status: "like").order(created_at: "DESC").map(&:to_user_id)
+   
+    like_users = []
+    like_user_ids.each do |like_user_id|
+      like_users << User.find(like_user_id)
+    end
+
+    @like_users = like_users
+    @like_users = Kaminari.paginate_array(@like_users).page(params[:page]).per(5)
+
+    got_reaction_user_ids = Reaction.where(to_user_id: current_user.id, status: 'like').pluck(:from_user_id)
+
+    @match_users = Reaction.where(to_user_id: got_reaction_user_ids, from_user_id: current_user.id, status: 'like').map(&:to_user)
+
+    # binding.pry
+
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,7 +45,7 @@
         <div
          class="user-action-common"
         >
-          <%=link_to user_path(@user) do %>
+          <%=link_to users_status_like_path(@user) do %>
             <i class="fas fa-heart fa-2x"></i>
             <i class="fas fa-user-alt fa-2x"></i>
           <% end %>

--- a/app/views/users/status/like/show.html.erb
+++ b/app/views/users/status/like/show.html.erb
@@ -1,0 +1,231 @@
+<div class="video-index-page", style="
+  max-height: fit-content;
+">
+  <%= render "partial/videos_page_navbar" %>
+
+  <div style="margin-bottom: 10px;">
+    <% breadcrumb :like_users %>
+    <%= breadcrumbs separator: " &rsaquo; " %>
+  </div>
+
+  <div
+  style="
+  display: block;
+  margin-left: 25px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  "
+  >
+    <%= @like_users.zip(@like_reaction_dates) do |like_user, date| %>
+      <div
+      style="
+      display: flex;
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <div
+          style="
+          margin-top: 30px;
+          font-weight: bold;
+          color: grey;
+          font-size: 16px;
+          "
+        >
+          <p>
+            <%= date.strftime("%Y/%m/%d") %>
+          </p>
+          <p
+          style="margin-top: -10px;"
+          >
+            <%= date.strftime("%H:%M") %>
+          </p>
+          <p
+          style="margin-top: -10px;"
+          >
+            タイプしました
+          </p>
+        </div>
+        <div
+        style="
+        margin-left: 30px;
+        margin-right: 10px;
+        display: block;
+        "
+        >
+          <%= link_to user_path(like_user),
+          style: 'text-decoration: none;' do %>
+            <% if like_user.profile_image.present? %>
+              <%= image_tag like_user.profile_image.url, style: "
+              width: 100px;
+              height: 100px;
+              border-radius: 50%;
+              " %>
+            <% else %>
+              <div 
+              class="profile-default-img",
+              style="
+              width: 100px;
+              height: 100px;
+              border-radius: 50%;
+              ">
+              </div>
+            <% end %>
+          <% end %>
+          <div
+          style="
+          margin-top: 5px;
+          margin-left: 30%;
+          font-size: 16px;
+          font-weight: bold;
+          color: grey;
+          width: 100px;
+          "
+          >
+            <p>
+              <%= like_user.name %>
+            </p>
+            <p
+            style="margin-top: -10px;"
+            >
+              さん
+            </p>
+          </div>
+        </div>
+        <div
+        style="
+        margin-top: 10px;
+        margin-left: 3px;
+        display: flex;
+        "
+        >
+          <% @match_users.each do |match_user| %>
+            <% if match_user == like_user %>
+              <div
+              style="
+              margin-top: -10px;
+              "
+              >
+                <div
+                style="
+                font-weight: bold;
+                font-size: 3px;
+                "
+                >
+                  <p>
+                    チャット
+                  </p>
+                  <p
+                  style="
+                  margin-top: -10px;
+                  "
+                  >
+                    しましょう！
+                  </p>
+                </div>
+              <%= link_to chat_rooms_path(params: { user_id: match_user.id }), style: 'text-decoration: none;',method: :post do %>
+                <div
+                style="
+                width: 50px;
+                height: 50px;
+                margin-top: -10px;
+                border: solid;
+                border-color: pink;
+                border-radius: 50%;
+                "
+                >
+                  <i class="fas fa-user-friends fa-2x"
+                  style="
+                  margin-left: 20%;
+                  margin-top: 25%;
+                  color: pink; 
+                  ">
+                  </i>
+                </div>
+              <% end %>
+                <div
+                style="
+                width: 50px;
+                height: 50px;
+                text-align: center;
+                margin-top: 5px;
+                font-size: 12px;
+                font-weight: bold;
+                color: grey;
+                "
+                >
+                  マッチ中
+                </div>
+              </div>
+            <% else %>
+              <div
+              style="
+              display: none;
+              width: 50px;
+              height: 50px;
+              "
+              >
+              </div>
+            <% end %>
+          <% end %>
+          <div
+          style="
+          margin-top: 20px;
+          margin-left: 10px;
+          margin-right: 10px;
+          display: block;
+          "
+          >
+            <%=link_to user_path(like_user), style: 'text-decoration: none;' do%>
+            <div
+            style="
+            width: 75px;
+            height: 50px;
+            border: solid;
+            border-radius: 10px 10px 10px 10px;
+            "
+            >
+              <i class="fas fa-share-alt fa-2x"
+              style="
+              margin-left: 15%;
+              margin-right: 5%;
+              "
+              >
+              </i>
+              <i class="fas fa-play-circle fa-2x"
+              style="
+              margin-left: 1%;
+              margin-top: 10px;
+              ">
+              </i>
+            </div>
+            <% end %>
+            <div
+            style="
+            text-align: center;
+            margin-top: 5px;
+            font-size: 12px;
+            font-weight: bold;
+            color: grey;
+            "
+            >
+              <p>
+                動画を
+              </p>
+              <p
+              style="margin-top: -10px;"
+              >
+                共有する
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= paginate @like_users %>
+  </div>
+
+</div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -39,6 +39,11 @@ crumb :user do |user|
   parent :root
 end
 
+crumb :like_users do |user|
+  link "タイプした人をみる", users_status_like_path
+  parent :user
+end
+
 crumb :shared_and_sharing_history  do |user|
   link "共有している動画をみる", youtube_myvideos_status_like_shared_and_sharing_history_path(user)
   parent :user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   resources :chat_rooms, only: [:create, :show]
   namespace :users do
     get 'video_common_like/:video_unique_id',  to: 'video_common_like#index', as: 'video_common_like'
+    namespace :status do
+      resources :like, only: [:show]
+    end
   end
   resources :qiitas
   namespace :youtube do


### PR DESCRIPTION
### タイプユーザー一覧ページの実装
``` ruby
like_user_ids = Reaction.where(from_user_id: @user.id, status: "like").order(created_at: "DESC").map(&:to_user_id)
   
like_users = []
like_user_ids.each do |like_user_id|
  like_users << User.find(like_user_id)
end

@like_users = like_users
```

### ページ内でマッチしているユーザーがわかるような表示をする
```@like_users```のeachループ内で
```@match_users```のeachループを実行して
```like_user == match_user```となる時に表示させる
