### PR TITLE
46 video sharing from like users index page / Likeユーザー一覧のページから共有動画を選択して共有

### DIFF
--- a/app/controllers/users/status/like_controller.rb
+++ b/app/controllers/users/status/like_controller.rb
@@ -1,5 +1,5 @@
 class Users::Status::LikeController < ApplicationController
-  def show
+  def index
     @user = User.find(params[:id])
 
     like_reactions = Reaction.where(from_user_id: @user.id, status: "like").order(created_at: "DESC")

--- a/app/controllers/users/video_share_controller.rb
+++ b/app/controllers/users/video_share_controller.rb
@@ -1,0 +1,27 @@
+class Users::VideoShareController < ApplicationController
+  def new
+    @user = User.find(params[:user_id])
+
+    favorite_states_by_current_user = Favorite.where(user_id: current_user.id, status: "like")
+
+    keyword = params[:keyword]
+    like_myvideos = []
+    
+    if keyword.present?
+      keyword_match_myvideos = YoutubeVideo.where('title LIKE ?', '%'+keyword+'%')
+      keyword_match_myvideos.each do |keyword_match_myvideo|
+        like_myvideos << YoutubeVideo.find(keyword_match_myvideo.id)
+      end
+    else
+      favorite_states_by_current_user.each do |favorite_state|
+        like_myvideos << YoutubeVideo.find(favorite_state.youtube_video_id)
+      end
+    end
+
+      
+    @like_myvideos = like_myvideos
+    @like_myvideos = Kaminari.paginate_array(@like_myvideos).page(params[:page]).per(3)
+
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find(params[:user_id])
 
     @share_video = YoutubeVideo.where(video_id: params[:share_video_unique_id]).first
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,6 +32,7 @@
     </div>
   </div>
 
+  <% if current_user.id == @user.id %>
   <div
   >
     <div
@@ -100,14 +101,13 @@
     </div>
   </div>
 
-  <% if current_user.id == @user.id %>
     <div class="user-action">
       <div class="user-action-common">
 
       <%= link_to destroy_user_session_path, method: :delete do %>
 
         <i class="fas fa-sign-out-alt fa-2x"></i>
-  <% end %>
+      <% end %>
       <p style="text-align: center;">ログアウト</p>
 
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -46,7 +46,7 @@
         <div
          class="user-action-common"
         >
-          <%=link_to users_status_like_path(@user) do %>
+          <%=link_to user_status_like_index_path do %>
             <i class="fas fa-heart fa-2x"></i>
             <i class="fas fa-user-alt fa-2x"></i>
           <% end %>

--- a/app/views/users/status/like/show.html.erb
+++ b/app/views/users/status/like/show.html.erb
@@ -176,7 +176,7 @@
           display: block;
           "
           >
-            <%=link_to user_path(like_user), style: 'text-decoration: none;' do%>
+            <%=link_to new_user_video_share_path(like_user), style: 'text-decoration: none;' do%>
             <div
             style="
             width: 75px;

--- a/app/views/users/video_share/new.html.erb
+++ b/app/views/users/video_share/new.html.erb
@@ -1,0 +1,129 @@
+<div class="user-index-page">
+  <%= render "partial/users_page_navbar", locals: { user: @user } %>
+  
+  <div>
+    <% breadcrumb :share_video_select, @user %>
+    <%= breadcrumbs separator: " &rsaquo; "%>
+  </div>
+
+  <div>
+    <div class="profile mt-4">
+      <% if @user.profile_image.present? %>
+        <%= image_tag @user.profile_image.url %>
+      <% else %>
+        <div 
+        class="profile-default-img",
+        style="
+        width: 100px;
+        height: 100px;
+        border-radius: 50%;
+        ">
+        </div>
+      <% end %>
+    </div>
+    <div
+    style="
+    font-weight: bold;
+    text-align: center;
+    "
+    >
+      <p>
+        <%= @user.name %>さんへ
+      </p>
+      <p
+      style="
+      margin-top: -10px;
+      "
+      >
+        動画を共有する
+      </p>
+    </div>
+
+    <%= form_with url: new_user_video_share_path, method: :get, local: true, class: 'cp_iptxt' do |f| %>
+      <div
+      >
+        <%= f.text_field :keyword, style: 'margin-left: 10%;', placeholder: "Likeした動画の中から検索" %>
+        <div style="display: flex; justify-content: center;">
+          <%= f.submit '検索する', class: 'btn btn-primary', style: 'margin-left: 15%; font-size: 16px;' %>
+          <%= link_to 'クリア', new_user_video_share_path, class: 'btn btn-secondary', style: 'margin-left: 15%; font-size: 16px;' %>
+        </div>
+      </div>
+    <% end %>
+
+
+    <div
+    style="
+    margin-left: 30px;
+    margin-right: 30px;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    "
+    >
+      <% @like_myvideos.each do |like_myvideo| %>
+        <div
+        style="
+        margin-top: 15px;
+        margin-bottom: 15px;
+        "
+        >
+          <div
+          style="
+          display: flex;
+          "
+          >
+            <div>
+              <iframe width="300" height="200" src="https://www.youtube.com/embed/<%= like_myvideo.video_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+              </iframe>
+            </div>
+            <%=link_to user_path(@user ,params: { 
+            share_video_unique_id: like_myvideo.video_id
+            }) do %>
+              <div
+              class="btn btn-primary"
+              style="
+              margin-top: 85px;
+              margin-left: 10px;
+              height: 30px;
+              font-size: 16px;
+              "
+              >
+                共有する
+              </div>
+            <% end  %>
+          </div>
+          <div
+          style="
+          margin-left: 15px;
+          margin-right: 15px;
+          "
+          >
+            <div
+            style="
+            font-weight: bold;
+            "
+            >
+              <%= like_myvideo.title %>
+            </div>
+            <div
+            style="
+            margin-left: 15px;
+            margin-right: 15px;
+            "
+            >
+              <%= like_myvideo.description %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div>
+    <%= paginate @like_myvideos %>
+  </div>
+
+
+
+
+
+</div>

--- a/app/views/youtube/myvideos/status/like/share/new.html.erb
+++ b/app/views/youtube/myvideos/status/like/share/new.html.erb
@@ -65,7 +65,7 @@
       margin-left: 5px;
       margin-right: 5px;
       ">
-        <div>
+        <div class="profile mt-4">
           <%= link_to user_path(user, params: {
             share_video_unique_id: @share_video.video_id,
           }) do %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -30,7 +30,7 @@ crumb :shared_and_sharing_videos_with_chat_room_user do |user|
 end
 
 crumb :user do |user|
-  user = User.find(params[:id])
+  user = User.find(params[:user_id])
   if user == current_user
     link "プロフィール : #{user.name}さん", user_path(user)
   else
@@ -40,8 +40,14 @@ crumb :user do |user|
 end
 
 crumb :like_users do |user|
-  link "タイプした人をみる", users_status_like_path
+  user = User.find(params[:user_id])
+  link "タイプした人をみる", user_status_like_index_path
   parent :user
+end
+
+crumb :share_video_select do |user|
+  link "#{user.name}さんと動画を共有する", new_user_video_share_path
+  parent :like_users
 end
 
 crumb :shared_and_sharing_history  do |user|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,15 +6,21 @@ Rails.application.routes.draw do
     }
     
   root 'top#index'
-  resources :users, only: [:show, :index]
+  resources :users, only: [:show, :index], param: :user_id
+  resources :users do
+    resources :video_share, only: [:new, :create], controller: 'users/video_share'
+    namespace :status do
+      resources :like, only: [:index], controller: 'users/status/like'
+    end
+  end
   resources :reactions, only: [:create]
   resources :matching, only: [:index]
   resources :chat_rooms, only: [:create, :show]
   namespace :users do
     get 'video_common_like/:video_unique_id',  to: 'video_common_like#index', as: 'video_common_like'
-    namespace :status do
-      resources :like, only: [:show]
-    end
+    # namespace :status do
+    #   resources :like, only: [:show]
+    # end
   end
   resources :qiitas
   namespace :youtube do
@@ -27,7 +33,7 @@ Rails.application.routes.draw do
         resources :like, only: [:index, :destroy]
         namespace :like do
           resources :share, only: [:new, :create]
-          resources :shared_and_sharing_history, only: [:show]
+          resources :shared_and_sharing_history, only: [:show], param: :user_id
           resources :sharing_videos, only: [:index]
           resources :sharing_videos, param: :video_unique_id, only: [:show]
           resources :shared_and_sharing_videos, only: [:show]


### PR DESCRIPTION
### ルーティングをネスト化
``` ruby
resources :users do
    resources :video_share, only: [:new, :create], controller: 'users/video_share'
    namespace :status do
      resources :like, only: [:index], controller: 'users/status/like'
    end
  end
```

### ルーティングネスト化に伴う修正
resourcesによるルーティングネスト化により
パラメータが id　→ user_idへ変更

ネスト化していない単体ルーティングのparamも変更
```
resources :users, only: [:show, :index], param: :user_id
```

```
user GET    /users/:user_id(.:format) users#show

```

これによりパンくずリストのリンクやナビバーのリンクで渡すパラメータを
user_idに統一