### PR TITLE
56 admin dashboard links / 管理者画面のリンク設定

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,4 +1,5 @@
 class Admin::ApplicationController < ApplicationController
+  layout 'admin'
   before_action :admin_user
 
   def index

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,21 +1,34 @@
 class Admin::ApplicationController < ApplicationController
   layout 'admin'
   before_action :admin_user
+  before_action :set_model_names
+  before_action :set_model_names
 
   def index
     # @table_names = ActiveRecord::Base.connection.tables.map{|t| t.classify}
     
     # @table_names = @table_names.drop(2)
     
+  end
+  
+  private
+  
+  def set_model_names
     table_names = ActiveRecord::Base.connection.tables.drop(2)
-    @columns = []
+
+    @table_names = []
     table_names.each do |table_name|
+     @table_names << table_name.chop
+    end
+  end
+  
+  def set_column_names
+    @table_names = ActiveRecord::Base.connection.tables.drop(2)
+    @columns = []
+    @table_names.each do |table_name|
       @columns << ActiveRecord::Base.connection.columns(table_name)
     end
-
   end
-
-  private
 
   def admin_user
     redirect_to(root_path) if  current_user.nil? || !current_user.admin?

--- a/app/controllers/admin/dashboard/chat_messages_controller.rb
+++ b/app/controllers/admin/dashboard/chat_messages_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::ChatMessagesController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_chat_message
   before_action :set_chat_message_model_name
   before_action :set_column_names_of_chat_message_model

--- a/app/controllers/admin/dashboard/chat_messages_controller.rb
+++ b/app/controllers/admin/dashboard/chat_messages_controller.rb
@@ -25,6 +25,39 @@ class Admin::Dashboard::ChatMessagesController < ApplicationController
     @chat_message.update(chat_message_params)
   end
 
+  def new
+    if ChatMessage.all.present?
+      chat_messages = ChatMessage.all
+      @new_chat_message_id = chat_messages.last.id+1
+    else
+      @new_chat_message_id = 1
+    end
+
+    @chat_message = ChatMessage.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_chat_message = column_names
+  end
+
+  def create
+    begin
+      @chat_message = ChatMessage.new(chat_message_params)
+      @chat_message.save!
+      redirect_to admin_dashboard_chat_messages_path
+    rescue ActiveRecord::RecordInvalid => e
+      @chat_message = e.record
+      p e.message
+    end
+  end
 
   
   def destroy
@@ -33,12 +66,10 @@ class Admin::Dashboard::ChatMessagesController < ApplicationController
     redirect_to admin_dashboard_chat_messages_path
   end
 
-
-
   private
   
   def set_chat_message_model_name
-  @model_name = ChatMessage.model_name.name
+    @model_name = ChatMessage.model_name.name
   end
   
   def set_column_names_of_chat_message_model
@@ -49,16 +80,18 @@ class Admin::Dashboard::ChatMessagesController < ApplicationController
       column_names << column.name
     end
     @column_names = column_names
-
   end
   
   def chat_message_params
-    params.require(:chat_message).permit(@column_names)
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    params.require(:chat_message).permit(column_names)
   end
-
 
   def admin_chat_message
     redirect_to(root_path) if  current_user.nil? || !current_user.admin?
   end
-
 end

--- a/app/controllers/admin/dashboard/chat_room_users_controller.rb
+++ b/app/controllers/admin/dashboard/chat_room_users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::ChatRoomUsersController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_chat_room_user_model_name
   before_action :set_column_names_of_chat_room_user_model

--- a/app/controllers/admin/dashboard/chat_room_users_controller.rb
+++ b/app/controllers/admin/dashboard/chat_room_users_controller.rb
@@ -22,7 +22,39 @@ class Admin::Dashboard::ChatRoomUsersController < ApplicationController
     @chat_room_user.update(chat_room_user_params)
   end
 
+  def new
+  if ChatRoomUser.all.present?
+      chat_room_users = ChatRoomUser.all
+      @new_chat_room_user_id = chat_room_users.last.id+1
+    else
+      @new_chat_room_user_id = 1
+    end
 
+    @chat_room_user = ChatRoomUser.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_chat_room_user = column_names
+  end
+
+  def create
+    begin
+      @chat_room_user = ChatRoomUser.new(chat_room_user_params)
+      @chat_room_user.save!
+      redirect_to admin_dashboard_chat_room_users_path
+    rescue ActiveRecord::RecordInvalid => e
+      @chat_room_user = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @chat_room_user = ChatRoomUser.find(params[:id])

--- a/app/controllers/admin/dashboard/chat_rooms_controller.rb
+++ b/app/controllers/admin/dashboard/chat_rooms_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::ChatRoomsController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_chat_room_model_name
   before_action :set_column_names_of_chat_room_model

--- a/app/controllers/admin/dashboard/chat_rooms_controller.rb
+++ b/app/controllers/admin/dashboard/chat_rooms_controller.rb
@@ -22,7 +22,39 @@ class Admin::Dashboard::ChatRoomsController < ApplicationController
     @chat_room.update(chat_room_params)
   end
 
+  def new
+    if ChatRoom.all.present?
+      chat_rooms = ChatRoom.all
+      @new_chat_room_id = chat_rooms.last.id+1
+    else
+      @new_chat_room_id = 1
+    end
 
+    @chat_room = ChatRoom.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_chat_room = column_names
+  end
+
+  def create
+    begin
+      @chat_room = ChatRoom.new(chat_room_params)
+      @chat_room.save!
+      redirect_to admin_dashboard_chat_rooms_path
+    rescue ActiveRecord::RecordInvalid => e
+      @chat_room = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @chat_room = ChatRoom.find(params[:id])
@@ -50,7 +82,7 @@ class Admin::Dashboard::ChatRoomsController < ApplicationController
   end
   
   def chat_room_params
-    params.require(:chat_room).permit(@column_names)
+    params.permit(@column_names)
   end
 
   def admin_user

--- a/app/controllers/admin/dashboard/favorites_controller.rb
+++ b/app/controllers/admin/dashboard/favorites_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::FavoritesController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_favorite_model_name
   before_action :set_column_names_of_favorite_model

--- a/app/controllers/admin/dashboard/favorites_controller.rb
+++ b/app/controllers/admin/dashboard/favorites_controller.rb
@@ -22,7 +22,39 @@ class Admin::Dashboard::FavoritesController < ApplicationController
     @favorite.update(favorite_params)
   end
 
+  def new
+    if Favorite.all.present?
+      favorites = Favorite.all
+      @new_favorite_id = favorites.last.id+1
+    else
+      @new_favorite_id = 1
+    end
 
+    @favorite = Favorite.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_favorite = column_names
+  end
+  
+  def create
+    begin
+      @favorite = Favorite.new(favorite_params)
+      @favorite.save!
+      redirect_to admin_dashboard_favorites_path
+    rescue ActiveRecord::RecordInvalid => e
+      @favorite = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @favorite = Favorite.find(params[:id])

--- a/app/controllers/admin/dashboard/reactions_controller.rb
+++ b/app/controllers/admin/dashboard/reactions_controller.rb
@@ -22,7 +22,39 @@ class Admin::Dashboard::ReactionsController < ApplicationController
     @reaction.update(reaction_params)
   end
 
+  def new
+    if Reaction.all.present?
+      reactions = Reaction.all
+      @new_reaction_id = reactions.last.id+1
+    else
+      @new_reaction_id = 1
+    end
 
+    @reaction = Reaction.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_reaction = column_names
+  end
+
+  def create
+    begin
+      @reaction = Reaction.new(reaction_params)
+      @reaction.save!
+      redirect_to admin_dashboard_reactions_path
+    rescue ActiveRecord::RecordInvalid => e
+      @reaction = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @reaction = Reaction.find(params[:id])

--- a/app/controllers/admin/dashboard/reactions_controller.rb
+++ b/app/controllers/admin/dashboard/reactions_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::ReactionsController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_reaction_model_name
   before_action :set_column_names_of_reaction_model

--- a/app/controllers/admin/dashboard/share_videos_controller.rb
+++ b/app/controllers/admin/dashboard/share_videos_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::ShareVideosController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_share_video_model_name
   before_action :set_column_names_of_share_video_model

--- a/app/controllers/admin/dashboard/share_videos_controller.rb
+++ b/app/controllers/admin/dashboard/share_videos_controller.rb
@@ -22,7 +22,39 @@ class Admin::Dashboard::ShareVideosController < ApplicationController
     @share_video.update(share_video_params)
   end
 
+  def new
+    if ShareVideo.all.present?
+      share_videos = ShareVideo.all
+      @new_share_video_id = share_videos.last.id+1
+    else
+      @new_share_video_id = 1
+    end
 
+    @share_video = ShareVideo.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_share_video = column_names
+  end
+  
+  def create
+    begin
+      @share_video = ShareVideo.new(share_video_params)
+      @share_video.save!
+      redirect_to admin_dashboard_share_videos_path
+    rescue ActiveRecord::RecordInvalid => e
+      @share_video = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @share_video = ShareVideo.find(params[:id])

--- a/app/controllers/admin/dashboard/users_controller.rb
+++ b/app/controllers/admin/dashboard/users_controller.rb
@@ -25,7 +25,39 @@ class Admin::Dashboard::UsersController < Admin::DashboardController
     @user.update(user_params)
   end
 
+  def new
+    if User.all.present?
+      users = User.all
+      @new_user_id = users.last.id+1
+    else
+      @new_user_id = 1
+    end
 
+    @user = User.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_user = column_names
+  end
+
+  def create
+    begin
+      @user = User.new(user_params)
+      @user.save!
+      redirect_to admin_dashboard_users_path
+    rescue ActiveRecord::RecordInvalid => e
+      @user = e.record
+      p e.message
+    end
+  end
   
   def destroy
     @user = User.find(params[:id])

--- a/app/controllers/admin/dashboard/users_controller.rb
+++ b/app/controllers/admin/dashboard/users_controller.rb
@@ -1,4 +1,6 @@
-class Admin::Dashboard::UsersController < ApplicationController
+class Admin::Dashboard::UsersController < Admin::DashboardController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_user_model_name
   before_action :set_column_names_of_user_model

--- a/app/controllers/admin/dashboard/youtube_videos_controller.rb
+++ b/app/controllers/admin/dashboard/youtube_videos_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Dashboard::YoutubeVideosController < ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+
   before_action :admin_user
   before_action :set_youtube_video_model_name
   before_action :set_column_names_of_youtube_video_model

--- a/app/controllers/admin/dashboard/youtube_videos_controller.rb
+++ b/app/controllers/admin/dashboard/youtube_videos_controller.rb
@@ -19,9 +19,46 @@ class Admin::Dashboard::YoutubeVideosController < ApplicationController
 
   def update
     @youtube_video = YoutubeVideo.find(params[:id])
-    @youtube_video.update(youtube_video_params)
+    if @youtube_video.update(youtube_video_params)
+      redirect_to admin_dashboard_youtube_videos_path(@youtube_video)
+    else
+      render :edit
+    end
   end
 
+  def new
+    if YoutubeVideo.all.present?
+      youtube_videos = YoutubeVideo.all
+      @new_youtube_video_id = youtube_videos.last.id+1
+    else
+      @new_youtube_video_id = 1
+    end
+
+    @youtube_video = YoutubeVideo.new
+
+    column_names = []
+    @columns.each do |column|
+      column_names << column.name
+    end
+    
+    column_names.reject! do |column_name| 
+      column_name == "id" ||
+      column_name == "updated_at" || column_name == "created_at"
+    end
+
+    @column_names_for_new_youtube_video = column_names
+  end
+
+  def create
+    begin
+      @youtube_video = YoutubeVideo.new(youtube_video_params)
+      @youtube_video.save!
+      redirect_to admin_dashboard_youtube_videos_path
+    rescue ActiveRecord::RecordInvalid => e
+      @youtube_video = e.record
+      p e.message
+    end
+  end
 
   
   def destroy

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,4 +1,6 @@
-class Admin::DashboardController < ApplicationController
+class Admin::DashboardController < Admin::ApplicationController
+  layout 'admin/dashboard/application.html.erb'
+  
   before_action :admin_user
 
   private
@@ -7,3 +9,4 @@ class Admin::DashboardController < ApplicationController
     redirect_to(root_path) if  current_user.nil? || !current_user.admin?
   end
 end
+

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :require_no_authentication, only: [:cancel]
 
   protected
 

--- a/app/views/admin/dashboard/chat_messages/edit.html.erb
+++ b/app/views/admin/dashboard/chat_messages/edit.html.erb
@@ -26,10 +26,10 @@
       >
         <div>
           <div>
-            <%= @chat_room_user.model_name.name %> モデルレコード
+            <%= @chat_message.model_name.name %> モデルレコード
           </div>
           <div>
-            id =<%= @chat_room_user.id %>
+            id =<%= @chat_message.id %>
           </div>
         </div>
         <div>
@@ -46,7 +46,7 @@
             margin-right: 5px;
             "
             >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+            <%= link_to admin_dashboard_chat_message_path(@chat_message) do %>
               <i class="fa fa-info-circle fa-1x"></i>
             <% end %>
             </div>
@@ -56,7 +56,7 @@
             margin-right: 5px;
             "
             >
-            <%= link_to edit_admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+            <%= link_to edit_admin_dashboard_chat_message_path(@chat_message) do %>
               <i class="fa fa-pen fa-1x"></i>
             <% end %>
             </div>
@@ -66,7 +66,7 @@
             margin-right: 5px;
             "
             >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user), method: :delete do %>
+            <%= link_to admin_dashboard_chat_message_path(@chat_message), method: :delete do %>
               <i class="fa fa-trash fa-1x"></i>
             <% end %>
             </div>
@@ -158,9 +158,9 @@
           
           <tr>
             <td>
-              <%= @chat_room_user.id %>
+              <%= @chat_message.id %>
             </td>
-            <% @chat_room_user.attributes.drop(1).take((@chat_room_user.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+            <% @chat_message.attributes.drop(1).take((@chat_message.attributes.size.to_f/2).ceil-1).each do |key, value| %>
             <td>
               <div
               style="
@@ -172,7 +172,7 @@
                   <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
                     <%= value %>
                   <% else %>
-                    <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
+                    <%= form_with model: [:admin, :dashboard, @chat_message] do |f| %>
                     <div>
                       <%= f.text_field "#{key}", style: 'width: 75px;' %>
                     </div>
@@ -213,9 +213,9 @@
         <% end %>
         </tr>
       </thead>
-       <tbody>
+      <tbody>
         <tr>
-          <% @chat_room_user.attributes.drop((@chat_room_user.attributes.size.to_f/2).ceil).each do |key, value| %>
+          <% @chat_message.attributes.drohfp((@chat_message.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
@@ -227,7 +227,7 @@
                   <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
                     <%= value %>
                   <% else %>
-                    <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
+                    <%= form_with model: [:admin, :dashboard, @chat_message] do |f| %>
                       <div>
                         <%= f.text_field "#{key}", style: 'width: 75px;' %>
                       </div>

--- a/app/views/admin/dashboard/chat_messages/index.html.erb
+++ b/app/views/admin/dashboard/chat_messages/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_messages/index.html.erb
+++ b/app/views/admin/dashboard/chat_messages/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @chat_messages.model_name.name %>モデルレコード
+        <p><%= @chat_messages.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% chat_message.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -172,6 +174,13 @@
      </table>
      <div>
        <%= paginate @chat_messages %>
+     </div>
+     <div>
+        <div
+        class="btn btn-primary"
+        >
+        <%= link_to "#{@chat_messages.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_chat_message_path, class: "text-white",style:"text-decoration: none;" %>
+        </div>
      </div>
     </div>
   </div>

--- a/app/views/admin/dashboard/chat_messages/new.html.erb
+++ b/app/views/admin/dashboard/chat_messages/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @chat_message.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_chat_message.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_chat_message_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @chat_message] do |f| %>
+              <div>
+                <% @column_names_for_new_chat_message.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_chat_messages_path(@chat_message) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @chat_message.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/chat_messages/show.html.erb
+++ b/app/views/admin/dashboard/chat_messages/show.html.erb
@@ -14,68 +14,34 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @chat_message.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @chat_message.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_message_path(@chat_message) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_chat_message_path(@chat_message) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_message_path(@chat_message), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @chat_message.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @chat_message.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 40%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @chat_message.attributes.each do |key, value| %>
             <td>
-              <%= @chat_message.id %>
-            </td>
-            <% @chat_message.attributes.drop(1).take((@chat_message.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @chat_message.attributes.drop((@chat_message.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@chat_message) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_user_path(@chat_message) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@chat_message), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/chat_messages/show.html.erb
+++ b/app/views/admin/dashboard/chat_messages/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_room_users/edit.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/edit.html.erb
@@ -14,71 +14,38 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @chat_room_user.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @chat_room_user.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_chat_room_user_path(@chat_room_user) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @chat_room_user.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @chat_room_user.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,134 +84,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 25%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil-1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @chat_room_user.id %>
+              <%= @chat_room_user.attributes.values.first %>
             </td>
-            <% @chat_room_user.attributes.drop(1).take((@chat_room_user.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+          <% @chat_room_user.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @chat_room_user.attributes.drop((@chat_room_user.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
-                      <div>
-                        <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                      </div>
-                      <div
-                      style="margin-top: 5px;"
-                      >
-                        <%= f.submit "更新する", class: "btn btn-primary"  %>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/chat_room_users/index.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_room_users/index.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @chat_room_users.model_name.name %>モデルレコード
+        <p><%= @chat_room_users.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 25%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% chat_room_user.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -173,6 +175,11 @@
      <div>
        <%= paginate @chat_room_users %>
      </div>
+      <div
+      class="btn btn-primary"
+      >
+        <%= link_to "#{@chat_room_users.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_chat_room_user_path, class: "text-white",style:"text-decoration: none;" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/dashboard/chat_room_users/new.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @chat_room_user.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_chat_room_user.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_chat_room_user_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @chat_room_user] do |f| %>
+              <div>
+                <% @column_names_for_new_chat_room_user.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_chat_room_users_path(@chat_room_user) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @chat_room_user.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/chat_room_users/show.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_room_users/show.html.erb
+++ b/app/views/admin/dashboard/chat_room_users/show.html.erb
@@ -14,68 +14,34 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @chat_room_user.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @chat_room_user.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_chat_room_user_path(@chat_room_user) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @chat_room_user.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @chat_room_user.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 25%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @chat_room_user.attributes.each do |key, value| %>
             <td>
-              <%= @chat_room_user.id %>
-            </td>
-            <% @chat_room_user.attributes.drop(1).take((@chat_room_user.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @chat_room_user.attributes.drop((@chat_room_user.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_chat_room_user_path(@chat_room_user) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_user_path(@chat_room_user), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/chat_rooms/edit.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_rooms/edit.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/edit.html.erb
@@ -14,71 +14,38 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @chat_room.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @chat_room.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_path(@chat_room) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_chat_room_path(@chat_room) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_path(@chat_room), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @chat_room.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @chat_room.id %></p>
       </div>
       <div
       style="
-      margin-top: 1%;
-      "
+      width: 100vw;
+      margin-top: 3%;
+      margin-left: auto;
+      margin-right: auto;
+  "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,77 +84,101 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 25%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
-          <tr>
+          <td>
+            <%= @chat_room.attributes.values.first %>
+          </td>
+          <% @chat_room.attributes.drop(1).each do |key, value| %>
             <td>
-              <%= @chat_room.id %>
+              <%= form_with model: [:admin, :dashboard, @chat_room] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
-            <% @chat_room.attributes.drop(1).each do |key, value| %>
+          <% end %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @chat_room] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_path(@chat_room) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_chat_room_path(@chat_room) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_path(@chat_room), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-            <% end %>
           </tr>
         </tbody>
      </table>

--- a/app/views/admin/dashboard/chat_rooms/index.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/chat_rooms/index.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @chat_rooms.model_name.name %>モデルレコード
+        <p><%= @chat_rooms.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 20%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% chat_room.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -173,6 +175,11 @@
      <div>
        <%= paginate @chat_rooms %>
      </div>
+      <div
+      class="btn btn-primary"
+      >
+        <%= link_to "#{@chat_rooms.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_chat_room_path, class: "text-white",style:"text-decoration: none;" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/dashboard/chat_rooms/new.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @chat_room.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_chat_room.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_chat_room_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @chat_room] do |f| %>
+              <div>
+                <% @column_names_for_new_chat_room.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_chat_rooms_path(@chat_room) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @chat_room.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/chat_rooms/show.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/show.html.erb
@@ -14,69 +14,35 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
-      margin-top: 6%;
+      width: 50vw;
+      margin-top: 2%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @chat_room.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @chat_room.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_path(@chat_room) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_chat_room_path(@chat_room) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_chat_room_path(@chat_room), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @chat_room.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @chat_room.id %></p>
       </div>
       <div
       style="
-      margin-top: 1%;
-      "
+      width: 100vw;
+      margin-top: 3%;
+      margin-left: auto;
+      margin-right: auto;
+  "
       >
         <table 
         border="1">
@@ -118,61 +84,90 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 25%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @chat_room.attributes.each do |key, value| %>
             <td>
-              <%= @chat_room.id %>
+              <%= value.to_s.truncate(20) %>
             </td>
-            <% @chat_room.attributes.drop(1).each do |key, value| %>
+          <% end %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <%= value.to_s.truncate(20) %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_path(@chat_room) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_chat_room_path(@chat_room) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_chat_room_path(@chat_room), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-            <% end %>
           </tr>
         </tbody>
      </table>

--- a/app/views/admin/dashboard/chat_rooms/show.html.erb
+++ b/app/views/admin/dashboard/chat_rooms/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/favorites/edit.html.erb
+++ b/app/views/admin/dashboard/favorites/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/favorites/edit.html.erb
+++ b/app/views/admin/dashboard/favorites/edit.html.erb
@@ -14,72 +14,41 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @favorite.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @favorite.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_favorite_path(@favorite) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_favorite_path(@favorite) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_favorite_path(@favorite), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @favorite.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @favorite.id %> [編集]</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
-          <thead>
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
             <tr>
               <th>
                 <div
@@ -115,134 +84,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil-1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @favorite.id %>
+              <%= @favorite.attributes.values.first %>
             </td>
-            <% @favorite.attributes.drop(1).take((@favorite.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+            <% @favorite.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @favorite] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @favorite] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
             <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @favorite.attributes.drop((@favorite.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @favorite] do |f| %>
-                      <div>
-                        <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                      </div>
-                      <div
-                      style="margin-top: 5px;"
-                      >
-                        <%= f.submit "更新する", class: "btn btn-primary"  %>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_favorite_path(@favorite) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_favorite_path(@favorite) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_favorite_path(@favorite), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-          <% end %>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/favorites/index.html.erb
+++ b/app/views/admin/dashboard/favorites/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/favorites/index.html.erb
+++ b/app/views/admin/dashboard/favorites/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @favorites.model_name.name %>モデルレコード
+        <p><%= @favorites.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% favorite.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -170,9 +172,14 @@
         <% end %>
         </tbody>
      </table>
-     <div>
-       <%= paginate @favorites %>
-     </div>
+    <div>
+      <%= paginate @favorites %>
+    </div>
+    <div
+    class="btn btn-primary"
+    >
+      <%= link_to "#{@favorites.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_favorite_path, class: "text-white",style:"text-decoration: none;" %>
+    </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/dashboard/favorites/new.html.erb
+++ b/app/views/admin/dashboard/favorites/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @favorite.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_favorite.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_favorite_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @favorite] do |f| %>
+              <div>
+                <% @column_names_for_new_favorite.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_favorites_path(@favorite) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @favorite.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/favorites/show.html.erb
+++ b/app/views/admin/dashboard/favorites/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/favorites/show.html.erb
+++ b/app/views/admin/dashboard/favorites/show.html.erb
@@ -14,68 +14,34 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @favorite.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @favorite.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_favorite_path(@favorite) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_favorite_path(@favorite) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_favorite_path(@favorite), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @favorite.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @favorite.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @favorite.attributes.each do |key, value| %>
             <td>
-              <%= @favorite.id %>
-            </td>
-            <% @favorite.attributes.drop(1).take((@favorite.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @favorite.attributes.drop((@favorite.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_favorite_path(@favorite) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_favorite_path(@favorite) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_favorite_path(@favorite), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -11,35 +11,6 @@
   "
   >
   <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
-  <div
   >
     <div
     style="

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -30,6 +30,7 @@
     "
     >
       <% @table_names.zip(@columns) do |table_name, columns| %>
+        <%= link_to send("admin_dashboard_#{table_name.underscore.downcase}s_path"), style:"text-decoration: none;" do %>
         <div
         style="
         display: block;
@@ -73,6 +74,7 @@
           </div>
           
         </div>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/dashboard/reactions/edit.html.erb
+++ b/app/views/admin/dashboard/reactions/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/reactions/edit.html.erb
+++ b/app/views/admin/dashboard/reactions/edit.html.erb
@@ -14,71 +14,37 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @reaction.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @reaction.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_reaction_path(@reaction) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_reaction_path(@reaction) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_reaction_path(@reaction), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @reaction.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,134 +83,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil-1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @reaction.id %>
+              <%= @reaction.attributes.values.first %>
             </td>
-            <% @reaction.attributes.drop(1).take((@reaction.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+            <% @reaction.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @reaction] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @reaction] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
             <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @reaction.attributes.drop((@reaction.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @reaction] do |f| %>
-                      <div>
-                        <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                      </div>
-                      <div
-                      style="margin-top: 5px;"
-                      >
-                        <%= f.submit "更新する", class: "btn btn-primary"  %>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_reaction_path(@reaction) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_reaction_path(@reaction) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_reaction_path(@reaction), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-          <% end %>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/reactions/index.html.erb
+++ b/app/views/admin/dashboard/reactions/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @reactions.model_name.name %>モデルレコード
+        <p><%= @reactions.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% reaction.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -173,6 +175,11 @@
      <div>
        <%= paginate @reactions %>
      </div>
+      <div
+      class="btn btn-primary"
+      >
+        <%= link_to "#{@reactions.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_reaction_path, class: "text-white",style:"text-decoration: none;" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/dashboard/reactions/index.html.erb
+++ b/app/views/admin/dashboard/reactions/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/reactions/new.html.erb
+++ b/app/views/admin/dashboard/reactions/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @reaction.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_reaction.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_reaction_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @reaction] do |f| %>
+              <div>
+                <% @column_names_for_new_reaction.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_reactions_path(@reaction) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @reaction.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/reactions/show.html.erb
+++ b/app/views/admin/dashboard/reactions/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/reactions/show.html.erb
+++ b/app/views/admin/dashboard/reactions/show.html.erb
@@ -1,4 +1,4 @@
-      <div
+<div
   style="
   width: 100%;
   height: 100vh;
@@ -14,68 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @reaction.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @reaction.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_reaction_path(@reaction) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_reaction_path(@reaction) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_reaction_path(@reaction), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @reaction.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +83,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @reaction.attributes.each do |key, value| %>
             <td>
-              <%= @reaction.id %>
-            </td>
-            <% @reaction.attributes.drop(1).take((@reaction.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @reaction.attributes.drop((@reaction.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_reaction_path(@reaction) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_reaction_path(@reaction) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_reaction_path(@reaction), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/share_videos/edit.html.erb
+++ b/app/views/admin/dashboard/share_videos/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/share_videos/edit.html.erb
+++ b/app/views/admin/dashboard/share_videos/edit.html.erb
@@ -14,71 +14,38 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @share_video.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @share_video.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_share_video_path(@share_video) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_share_video_path(@share_video) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_share_video_path(@share_video), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @share_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @share_video.id %> [編集]</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,134 +84,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil-1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @share_video.id %>
+              <%= @share_video.attributes.values.first %>
             </td>
-            <% @share_video.attributes.drop(1).take((@share_video.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+            <% @share_video.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @share_video] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @share_video] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
             <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @share_video.attributes.drop((@share_video.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @share_video] do |f| %>
-                      <div>
-                        <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                      </div>
-                      <div
-                      style="margin-top: 5px;"
-                      >
-                        <%= f.submit "更新する", class: "btn btn-primary"  %>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_share_video_path(@share_video) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_share_video_path(@share_video) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_share_video_path(@share_video), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-          <% end %>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/share_videos/index.html.erb
+++ b/app/views/admin/dashboard/share_videos/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/share_videos/index.html.erb
+++ b/app/views/admin/dashboard/share_videos/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @share_videos.model_name.name %>モデルレコード
+        <p><%= @share_videos.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% share_video.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -173,6 +175,11 @@
      <div>
        <%= paginate @share_videos %>
      </div>
+      <div
+      class="btn btn-primary"
+      >
+        <%= link_to "#{@share_videos.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_share_video_path, class: "text-white",style:"text-decoration: none;" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/dashboard/share_videos/new.html.erb
+++ b/app/views/admin/dashboard/share_videos/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @share_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_share_video.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_share_video_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @share_video] do |f| %>
+              <div>
+                <% @column_names_for_new_share_video.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_share_videos_path(@share_video) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @share_video.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/share_videos/show.html.erb
+++ b/app/views/admin/dashboard/share_videos/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/share_videos/show.html.erb
+++ b/app/views/admin/dashboard/share_videos/show.html.erb
@@ -14,68 +14,34 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @share_video.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @share_video.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_share_video_path(@share_video) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_share_video_path(@share_video) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_share_video_path(@share_video), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @share_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @share_video.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 30%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @share_video.attributes.each do |key, value| %>
             <td>
-              <%= @share_video.id %>
-            </td>
-            <% @share_video.attributes.drop(1).take((@share_video.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @share_video.attributes.drop((@share_video.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_share_video_path(@share_video) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_share_video_path(@share_video) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_share_video_path(@share_video), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/users/edit.html.erb
+++ b/app/views/admin/dashboard/users/edit.html.erb
@@ -14,71 +14,38 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            Userモデルレコード
-          </div>
-          <div>
-            id =<%= @user.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_user_path(@user) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_user_path(@user) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_user_path(@user), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @user.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @user.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,114 +84,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 40%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @user.id %>
+              <%= @user.attributes.values.first %>
             </td>
-            <% @user.attributes.drop(1).take((@user.attributes.size.to_f/2).ceil).each do |key, value| %>
+            <% @user.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <%= form_with model: [:admin, :dashboard, @user] do |f| %>
-                    <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    <%= f.submit %>
-                  <% end %>
-                <% else %> 
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @user] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
             <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @user.attributes.drop((@user.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <%= form_with model: [:admin, :dashboard, @user] do |f| %>
-                    <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    <%= f.submit %>
-                  <% end %>
-                <% else %> 
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@user) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_user_path(@user) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@user), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-          <% end %>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/users/edit.html.erb
+++ b/app/views/admin/dashboard/users/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="
@@ -108,7 +79,9 @@
       "
       >
         <table border="1">
-          <thead>
+          <thead
+          class="table-dark"
+          >
             <tr>
               <th>
                 <div

--- a/app/views/admin/dashboard/users/index.html.erb
+++ b/app/views/admin/dashboard/users/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/users/index.html.erb
+++ b/app/views/admin/dashboard/users/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-      <%= @users.model_name.name %>モデルレコード
+        <p><%= @users.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 40%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% user.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -172,6 +174,13 @@
      </table>
      <div>
        <%= paginate @users %>
+     </div>
+     <div>
+        <div
+        class="btn btn-primary"
+        >
+        <%= link_to "#{@users.model_name.name}モデルレコードを新規作成する", new_user_registration_path, class: "text-white",style:"text-decoration: none;" %>
+        </div>
      </div>
     </div>
   </div>

--- a/app/views/admin/dashboard/users/show.html.erb
+++ b/app/views/admin/dashboard/users/show.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="
@@ -108,7 +79,6 @@
       "
       >
         <table 
-        class="table"
         border="1">
           <thead
           class="table-dark"

--- a/app/views/admin/dashboard/users/show.html.erb
+++ b/app/views/admin/dashboard/users/show.html.erb
@@ -14,68 +14,34 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @user.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @user.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_user_path(@user) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_user_path(@user) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_user_path(@user), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @user.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @user.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -118,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 40%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @user.attributes.each do |key, value| %>
             <td>
-              <%= @user.id %>
-            </td>
-            <% @user.attributes.drop(1).take((@user.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @user.attributes.drop((@user.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@user) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_user_path(@user) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_user_path(@user), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/youtube_videos/edit.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/edit.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="
@@ -108,7 +79,9 @@
       "
       >
         <table border="1">
-          <thead>
+          <thead
+          class="table-dark"
+          >
             <tr>
               <th>
                 <div

--- a/app/views/admin/dashboard/youtube_videos/edit.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/edit.html.erb
@@ -14,71 +14,38 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @youtube_video.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @youtube_video.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_youtube_video_path(@youtube_video) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_youtube_video_path(@youtube_video) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_youtube_video_path(@youtube_video), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @youtube_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @youtube_video.id %> [編集]</p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
-        <table border="1">
+        <table 
+        border="1">
           <thead
           class="table-dark"
           >
@@ -117,134 +84,104 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2).ceil-1).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
             <td>
-              <%= @youtube_video.id %>
+              <%= @youtube_video.attributes.values.first %>
             </td>
-            <% @youtube_video.attributes.drop(1).take((@youtube_video.attributes.size.to_f/2).ceil-1).each do |key, value| %>
+            <% @youtube_video.attributes.drop(1).each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") ||key.eql?("title") ||key.eql?("published_at") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @youtube_video] do |f| %>
-                    <div>
-                      <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                    </div>
-                    <div
-                    style="margin-top: 5px;"
-                    >
-                      <%= f.submit "更新する", class: "btn btn-primary" %>
-                    </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
-                <% end %>
-              </div>
+              <%= form_with model: [:admin, :dashboard, @youtube_video] do |f| %>
+                <div>
+                  <%= f.text_field "#{key}", style: 'width: 75px;' %>
+                </div>
+                <div
+                style="margin-top: 5px;"
+                >
+                  <%= f.submit "更新する", class: "btn btn-primary"  %>
+                </div>
+              <% end %>
             </td>
             <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @youtube_video.attributes.drop((@youtube_video.attributes.size.to_f/2).ceil).each do |key, value| %>
             <td>
               <div
               style="
-              margin-left: 10px;
-              margin-right: 10px;
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
               "
               >
-                <% if value.present? %>
-                  <% if key.eql?("video_id") || key.eql?("channel_id")||key.eql?("channel_title")||key.eql?("thumbnail_url") %>
-                    <%= value %>
-                  <% else %>
-                    <%= form_with model: [:admin, :dashboard, @youtube_video] do |f| %>
-                      <div>
-                        <%= f.text_field "#{key}", style: 'width: 75px;' %>
-                      </div>
-                      <div
-                      style="margin-top: 5px;"
-                      >
-                        <%= f.submit "更新する", class: "btn btn-primary"  %>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% else %>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_youtube_video_path(@youtube_video) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
                 <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_youtube_video_path(@youtube_video) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_youtube_video_path(@youtube_video), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
               </div>
             </td>
-          <% end %>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/youtube_videos/index.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/index.html.erb
@@ -10,35 +10,6 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
   <div>
     <div
     style="

--- a/app/views/admin/dashboard/youtube_videos/index.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/index.html.erb
@@ -14,21 +14,33 @@
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <%= @youtube_videos.model_name.name %>モデルレコード
+      <p><%= @youtube_videos.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
       </div>
       <div
       style="
-      margin-top: 1%;
+      width: 100vw;
+      margin-top: 2%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -71,8 +83,12 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
     "
     >
       <table
@@ -85,14 +101,7 @@
           <tr>
           <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 10px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
             <th
@@ -116,14 +125,7 @@
           <tr>
           <% youtube_video.attributes.each do |key, value| %>
             <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
               <%= value.to_s.truncate(20) %>
-              </div>
             </td>
           <% end %>
             <td>
@@ -172,6 +174,13 @@
      </table>
      <div>
        <%= paginate @youtube_videos %>
+     </div>
+      <div>
+        <div
+        class="btn btn-primary"
+        >
+          <%= link_to "#{@youtube_videos.model_name.name}モデルレコードを新規作成する", new_admin_dashboard_youtube_video_path, class: "text-white",style:"text-decoration: none;" %>
+        </div>
      </div>
     </div>
   </div>

--- a/app/views/admin/dashboard/youtube_videos/new.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/new.html.erb
@@ -1,0 +1,161 @@
+<div
+  style="
+  width: 100%;
+  height: 100vh;
+  background-color:#F5FFFA;
+  "
+>
+  <div
+  style="
+  display: flex;
+  "
+  >
+  <div>
+    <div
+    style="
+    display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
+    "
+    >
+      <div
+      style="
+      width: 50vw;
+      margin-top: 6%;
+      margin-left: 30%;
+      margin-right: 1%;
+      font-size: 20px;
+      "
+      >
+        <p><%= @youtube_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>新規作成</p>
+      </div>
+      <div
+      style="
+      width: 100vw;
+      margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
+      "
+      >
+        <table 
+        border="1">
+          <thead
+          class="table-dark"
+          >
+            <tr>
+              <th>
+                <div
+                style="
+                text-align: center;
+                font-size: 20px;
+                font-weight: bold;
+                "
+                >
+                  <%= @model_name %>
+                </div>
+              </th>
+            </tr>
+          </thead>
+
+          <% @column_names.each do |column_name|  %>
+          <tr>
+            <td>
+              <div
+              style="
+              margin-left: 10px;
+              margin-right: 10px;
+              "
+              >
+              <%= column_name %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    <div
+    style="
+    margin-top: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
+    "
+    >
+      <table
+      class="table" 
+      border="1"
+      >
+        <thead
+        class="table-dark"
+        >
+          <tr>
+            <th>
+              id
+            </th>
+            <% @column_names_for_new_youtube_video.each do |column_name| %>
+            <th>
+              <%= column_name.truncate(10) %>
+            </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+            <%= @new_youtube_video_id %>
+            </td>
+            <%= form_with model: [:admin, :dashboard, @youtube_video] do |f| %>
+              <div>
+                <% @column_names_for_new_youtube_video.each do |column| %>
+                <td>
+                <%= f.text_field "#{column}", style: 'width: 75px;' %>
+                </td>
+                <% end %>
+              </div>
+          </tr>
+        </tbody>
+      </table>
+      <div
+      style="
+      margin-top: 10px;
+      margin-bottom: 10px;
+      "
+      >
+        <%= f.submit "作成する", class: "btn btn-primary"  %>
+      </div>
+      <% end %>
+      <%= link_to admin_dashboard_youtube_videos_path(@youtube_video) do %>
+        <div
+        style="
+        display: flex;
+        justify-content: center;
+        margin-top: 5%;
+        "
+        >
+          <div>
+            <i class="fa fa-table fa-2x"></i>
+          </div>
+          <div
+          style="
+          margin-top: 3px;
+          margin-left: 3px;
+          "
+          >
+            <%= @youtube_video.model_name.name %>レコード一覧画面へ
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/dashboard/youtube_videos/show.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/show.html.erb
@@ -10,73 +10,38 @@
   display: flex;
   "
   >
-  
   <div>
     <div
     style="
     display: flex;
+    position: fixed;
+    top: 50px;
+    left: 20vw;
+    width: 60vw;
+    margin-top: 1%;
     "
     >
       <div
       style="
+      width: 50vw;
       margin-top: 6%;
       margin-left: 30%;
       margin-right: 1%;
-      font-size: 32px;
+      font-size: 20px;
       "
       >
-        <div>
-          <div>
-            <%= @youtube_video.model_name.name %> モデルレコード
-          </div>
-          <div>
-            id =<%= @youtube_video.id %>
-          </div>
-        </div>
-        <div>
-          <div
-          style="
-          margin-left: 5px;
-          margin-right: 5px;
-          display: flex;
-          "
-          >
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_youtube_video_path(@youtube_video) do %>
-              <i class="fa fa-info-circle fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to edit_admin_dashboard_youtube_video_path(@youtube_video) do %>
-              <i class="fa fa-pen fa-1x"></i>
-            <% end %>
-            </div>
-            <div
-            style="
-            margin-left: 5px;
-            margin-right: 5px;
-            "
-            >
-            <%= link_to admin_dashboard_youtube_video_path(@youtube_video), method: :delete do %>
-              <i class="fa fa-trash fa-1x"></i>
-            <% end %>
-            </div>
-          </div>
-        </div>
+        <p><%= @youtube_video.model_name.name %>モデル</p>
+        <p
+        style="margin-top: -5%;"
+        >レコード</p>
+        <p>id = <%= @youtube_video.id %></p>
       </div>
       <div
       style="
+      width: 100vw;
       margin-top: 1%;
+      margin-left: auto;
+      margin-right: auto;
       "
       >
         <table 
@@ -119,102 +84,92 @@
     <div
     style="
     margin-top: 1%;
-    margin-left: 1%;
-    margin-right: 1%;
+    text-align: center;
+    width: 100vw;
+    position: fixed;
+    top: 45%;
+    margin-left:auto;
+    margin-right:auto;
     "
-    class="table-responsive"
     >
       <table
-      class="table"
+      class="table" 
       border="1"
       >
         <thead
         class="table-dark"
         >
           <tr>
+          <% @column_names.each do |column_name| %>
             <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
-                id
-              </div>
-            </th>
-          <% @column_names.drop(1).take((@column_names.size.to_f/2-1).ceil).each do |column_name| %>
-            <th>
-              <div
-              style="
-              text-align: center;
-              font-size: 20px;
-              "
-              >
               <%= column_name.truncate(10) %>
-              </div>
             </th>
           <% end %>
+            <th
+            style="
+              width: 100px;
+            "
+            >
+              <div
+              style="
+              text-align: center;
+              font-size: 10px;
+              "
+              >
+              レコード操作
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
-          
           <tr>
+          <% @youtube_video.attributes.each do |key, value| %>
             <td>
-              <%= @youtube_video.id %>
-            </td>
-            <% @youtube_video.attributes.drop(1).take((@youtube_video.attributes.size.to_f/2-1).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value.to_s.truncate(20) %>
-              </div>
-            </td>
-            <% end %>
-          </tr>
-        </tbody>
-     </table>
-     <table
-     class="table"
-     border="1"
-     >
-       <thead
-       class="table-dark"
-       >
-        <tr>
-        <% @column_names.drop((@column_names.size.to_f/2).ceil).each do |column_name| %>
-          <th>
-            <div
-            style="
-            text-align: center;
-            font-size: 20px;
-            "
-            >
-            <%= column_name.truncate(10) %>
-            </div>
-          </th>
-        <% end %>
-        </tr>
-      </thead>
-       <tbody>
-        <tr>
-          <% @youtube_video.attributes.drop((@youtube_video.attributes.size.to_f/2).ceil).each do |key, value| %>
-            <td>
-              <div
-              style="
-              margin-left: 10px;
-              margin-right: 10px;
-              "
-              >
-                <%= value %>
-              </div>
+              <%= value.to_s.truncate(20) %>
             </td>
           <% end %>
-        </tr>
-      </tbody>
+            <td>
+              <div
+              style="
+              margin-left: 5px;
+              margin-right: 5px;
+              display: flex;
+              "
+              >
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_youtube_video_path(@youtube_video) do %>
+                  <i class="fa fa-info-circle fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to edit_admin_dashboard_youtube_video_path(@youtube_video) do %>
+                  <i class="fa fa-pen fa-2x"></i>
+                <% end %>
+                </div>
+                <div
+                style="
+                margin-left: 5px;
+                margin-right: 5px;
+                "
+                >
+                <%= link_to admin_dashboard_youtube_video_path(@youtube_video), method: :delete do %>
+                  <i class="fa fa-trash fa-2x"></i>
+                <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
      </table>
     </div>
   </div>

--- a/app/views/admin/dashboard/youtube_videos/show.html.erb
+++ b/app/views/admin/dashboard/youtube_videos/show.html.erb
@@ -10,35 +10,7 @@
   display: flex;
   "
   >
-  <div
-  style="
-  width: 15%;
-  height: 100vh;
-  background-color:#EEEEEE;
-  "
-  >
-    <div
-    style="
-    font-weight: bold;
-    font-size: 24px;
-    "
-    >
-    App for Admin
-    </div>
-    <% @table_names.each do |table_name| %>
-      <div
-      style="
-      font-weight: bold;
-      font-size: 16px;
-      margin-left: 15px;
-      margin-top: 10px;
-      margin-bottom: 10px;
-      "
-      >
-        <%= table_name %>
-      </div>
-    <% end %>
-  </div>
+  
   <div>
     <div
     style="

--- a/app/views/admin/partial/_drawer_menu.html.erb
+++ b/app/views/admin/partial/_drawer_menu.html.erb
@@ -3,9 +3,32 @@ style="
 background-color: #EEEEEE;
 "
 >
-  <ul class="drawer-menu">
-    <li><a class="drawer-brand" href="#">Brand</a></li>
-    <li><a class="drawer-menu-item" href="#">Nav1</a></li>
-    <li><a class="drawer-menu-item" href="#">Nav2</a></li>
+  <div
+  style="
+  font-size: 24px;
+  font-weight: bold;
+  "
+  >
+    App for Admin
+  </div>
+  <ul 
+  class="drawer-menu"
+  style="
+  list-style: none;
+  "
+  >
+    <% @table_names.each do |table_name| %>
+      <li
+      style="
+      magin-top: 15px;
+      margin-bottom: 15px;
+      margin-left: 10px;
+      font-size: 16px;
+      font-weight: bold;
+      "
+      >
+        <%= link_to table_name, send("admin_dashboard_#{table_name.underscore.downcase}s_path"), style:"text-decoration: none;"  %>
+      </li>
+    <% end %>
   </ul>
 </nav>

--- a/app/views/admin/partial/_drawer_menu.html.erb
+++ b/app/views/admin/partial/_drawer_menu.html.erb
@@ -9,7 +9,7 @@ background-color: #EEEEEE;
   font-weight: bold;
   "
   >
-    App for Admin
+    <%= link_to 'App for Admin', admin_dashboard_index_path %>
   </div>
   <ul 
   class="drawer-menu"
@@ -27,7 +27,7 @@ background-color: #EEEEEE;
       font-weight: bold;
       "
       >
-        <%= link_to table_name, send("admin_dashboard_#{table_name.underscore.downcase}s_path"), style:"text-decoration: none;"  %>
+        <%= link_to table_name, send("admin_dashboard_#{table_name.underscore.downcase}s_path")  %>
       </li>
     <% end %>
   </ul>

--- a/app/views/admin/partial/_drawer_menu.html.erb
+++ b/app/views/admin/partial/_drawer_menu.html.erb
@@ -1,0 +1,11 @@
+<nav class="drawer-nav" role="navigation"
+style="
+background-color: #EEEEEE;
+"
+>
+  <ul class="drawer-menu">
+    <li><a class="drawer-brand" href="#">Brand</a></li>
+    <li><a class="drawer-menu-item" href="#">Nav1</a></li>
+    <li><a class="drawer-menu-item" href="#">Nav2</a></li>
+  </ul>
+</nav>

--- a/app/views/admin/partial/_header.html.erb
+++ b/app/views/admin/partial/_header.html.erb
@@ -1,0 +1,14 @@
+<header 
+role="banner"
+style="
+background-color: #EEEEEE;
+width: 100vw;
+height: 50px;
+"
+>
+  <button type="button" class="drawer-toggle drawer-hamburger">
+    <span class="sr-only">toggle navigation</span>
+    <span class="drawer-hamburger-icon"></span>
+  </button>
+  <%= render 'admin/partial/drawer_menu' %>
+</header>

--- a/app/views/admin/partial/_header.html.erb
+++ b/app/views/admin/partial/_header.html.erb
@@ -1,9 +1,13 @@
 <header 
 role="banner"
 style="
+z-index: 100;
 background-color: #EEEEEE;
 width: 100vw;
 height: 50px;
+position: fixed;
+top: 0px;
+left: 0px;
 "
 >
   <button type="button" class="drawer-toggle drawer-hamburger">

--- a/app/views/layouts/admin/dashboard/application.html.erb
+++ b/app/views/layouts/admin/dashboard/application.html.erb
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>SwipeMatchingApp</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application'%>
+  
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
+    <!-- drawer.css -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/drawer/3.2.2/css/drawer.min.css">
+    <!-- jquery & iScroll -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/iScroll/5.2.0/iscroll.min.js"></script>
+    <!-- drawer.js -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/drawer/3.2.2/js/drawer.min.js"></script>
+  </head>
+
+  <body class="drawer drawer--left">
+    <%= render 'admin/partial/header' %>
+    <%= yield %>
+  </body>
+</html>
+
+<script>
+  $(document).ready(function() {
+    $('.drawer').drawer();
+  });
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,37 @@ ja:
       previous: <i class="fas fa-angle-left"></i>
       next: <i class="fas fa-angle-right"></i>
       truncate: "..."
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください

--- a/package-lock.json
+++ b/package-lock.json
@@ -3955,11 +3955,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -4623,6 +4618,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "iscroll": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/iscroll/-/iscroll-5.2.0.tgz",
+      "integrity": "sha1-1RMwcIi1slpPiTr0dIBEaEgYKcg="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4663,9 +4663,14 @@
       }
     },
     "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+    },
+    "jquery-drawer": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jquery-drawer/-/jquery-drawer-3.2.2.tgz",
+      "integrity": "sha1-KRm4cjK5HntZFaa3DaEuOZ7wMss="
     },
     "js-base64": {
       "version": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "^4.5.3",
-    "jquery": "^3.5.1",
+    "iscroll": "^5.2.0",
+    "jquery": "^2.2.4",
+    "jquery-drawer": "^3.2.2",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"
   },


### PR DESCRIPTION
### ドロワー・ヘッダーの修正
z-indexの変更
close #182 

### ドロワーリンクの実装
sendメソッドでeachループの変数をlink_toで用いる
close #183

###　スタイル修正
ヘッダー・ドロワーのz-index変更による
レコード一覧・詳細・編集画面のスタイルの修正

### レコード作成画面の修正
#### ユーザー作成画面
```encrypted password```を直接入力してユーザーを作成することは不可能
→管理者画面からアプリ内のユーザー作成画面へ遷移できるように実装

``` ruby
class RegistrationsController < Devise::RegistrationsController
  # prepend_before_action :require_no_authentication, only: [:new, :create, :cancel]
  # ↑もともとのdeviseのソースコード
  
  prepend_before_action :require_no_authentication, only: [:cancel]
  # ソースコードに対してオーバーライド
```

### ハッシュは末尾要素を削除できない
ハッシュに対して末尾要素を削除するメソッドはない
→ @user.attributes (ハッシュ)の要素を配列化

